### PR TITLE
Feature (Issue #13): View item purchase details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2008,6 +2008,14 @@
         "react-transition-group": "^4.4.0"
       }
     },
+    "@material-ui/icons": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.9.1.tgz",
+      "integrity": "sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.11.0",
+    "@material-ui/icons": "^4.9.1",
     "axios": "^0.19.2",
     "firebase": "^7.18.0",
     "husky": "^3.1.0",

--- a/src/components/AddItem/AddItem.style.scss
+++ b/src/components/AddItem/AddItem.style.scss
@@ -4,6 +4,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    margin-bottom: 6rem;
 
     &__wrapper {
       display: flex;
@@ -29,7 +30,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 6rem;
+  margin-bottom: 2rem;
   font-size: 1.1rem;
   background: rgb(8, 176, 243);
   width: 200px;

--- a/src/components/Item/Item.component.jsx
+++ b/src/components/Item/Item.component.jsx
@@ -17,7 +17,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 const Item = props => {
   const itemId = props.id.toString();
   const secondsInDay = 86400;
-  let lastPurchasedTimeInSeconds = 0;
+  let lastPurchasedTimeInSeconds = props.purchasedTimeInSeconds;
   const itemName = props.name;
   const localToken = props.localToken;
   const over24 = props.over24;
@@ -29,7 +29,6 @@ const Item = props => {
   let lastPurchaseDate = props.date;
 
   // Future implementation;  currently breaks but that's a low-priority issue.
-
   // const { itemName, localToken, over24, resupplyPeriod } = props;
   // let {
   //   lastEstimate,
@@ -102,51 +101,48 @@ const Item = props => {
       });
   };
 
-  useEffect(() => {
-    if (!over24) {
-      // document.getElementById('item__name').style.textDecoration =
-      //   'line-through';
-      document.getElementById('item__name').style.textDecoration =
-        'line-through';
-    }
-    // To highlight the items based on resupplyPeriod
-    if (resupplyPeriod === 7) {
-      document.getElementById(itemId).setAttribute('class', 'list__item--soon');
-      return;
-    } else if (resupplyPeriod === 14) {
-      document
-        .getElementById(itemId)
-        .setAttribute('class', 'list__item--kind-of-soon');
-      return;
-    } else if (resupplyPeriod === 30) {
-      document
-        .getElementById(itemId)
-        .setAttribute('class', 'list__item--not-soon');
-      return;
-    } else if (
-      numberOfPurchases < 2 ||
-      lastPurchasedTimeInSeconds > 2 * nextPurchaseInterval
-    ) {
-      document
-        .getElementById(itemId)
-        .setAttribute('class', 'list__item--inactive');
-    }
+  // Variable set up for easy theming whenever we want to get rid of these LOVELY colours LUL
+  let accordionColor;
 
-    // Set a state object thingmabob to act as dependency array trigger
-    // Handle Change method
+  // Switch statement which looks for the resupply period  to match:
+  // soon (7), kind of soon (14), and not soon (30).
+  switch (resupplyPeriod) {
+    case 7:
+      accordionColor = 'yellow';
+      break;
 
-    //create over24 as local state, and pass props.over24 as its value, aka
-    // const [over24, setOver24] = useState(props.over24)
+    case 14:
+      accordionColor = 'red';
+      break;
 
-    // useEffect(() => {
-    // do magic
-    // }, [over24])
-  });
+    default:
+      accordionColor = 'green';
+  }
+
+  //Secondary Switch statement which looks for if items in list are inactive or not.
+  // Since user simulates purchase by clicking on checkbox, user should click twice to get assigned a new colour,
+  // As it will (correctly) default to purple. Speaking of 'default', I set the default statement as 'break' here
+  // purposefully. The 'correct' approach would have been to not use a switch statement for this case, but I wanted
+  // To keep the approach of theming similar for ease of developer customization: simply change accordionColor below
+  // to change...the accordionColor.
+
+  switch (
+    numberOfPurchases < 2 ||
+    lastPurchasedTimeInSeconds > 2 * nextPurchaseInterval
+  ) {
+    case true:
+      accordionColor = 'purple';
+      break;
+
+    default:
+      break;
+  }
 
   return (
     <Accordion
-      id={itemId}
+      style={{ background: `${accordionColor}` }}
       aria-label={`Estimated number of days till next next purchase: ${nextPurchaseInterval}`}
+      className={`${resupplyPeriod === 7 ? 'list__item--soon' : ''}`}
     >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
@@ -159,7 +155,12 @@ const Item = props => {
           value="checkedItem"
           inputProps={{ 'aria-label': 'Checkbox Item' }}
         />
-        <h1 id="item__name">{itemName}</h1>
+        <span
+          id="item__name"
+          style={{ textDecoration: !over24 ? 'line-through' : 'none' }}
+        >
+          {itemName}
+        </span>
       </AccordionSummary>
       <AccordionDetails className="accordion__details">
         <div className="flex-container">

--- a/src/components/Item/Item.component.jsx
+++ b/src/components/Item/Item.component.jsx
@@ -1,22 +1,47 @@
-import React, { useEffect } from 'react';
-import * as firebase from '../../lib/firebase';
+// React Imports
+import React, { useState, useEffect } from 'react';
+
+// Custom Imports
 import calculateEstimate from '../../lib/estimates';
-import Checkbox from '@material-ui/core/Checkbox';
+import * as firebase from '../../lib/firebase';
 import './Item.style.scss';
 
+// Material-UI Imports
+import Accordion from '@material-ui/core/Accordion';
+import AccordionSummary from '@material-ui/core/AccordionSummary';
+import AccordionDetails from '@material-ui/core/AccordionDetails';
+import Typography from '@material-ui/core/Typography';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
+import Checkbox from '@material-ui/core/Checkbox';
+
 const Item = props => {
-  const itemName = props.name;
   const itemId = props.id.toString();
+  const secondsInDay = 86400;
+  let lastPurchasedTimeInSeconds = 0;
+  const itemName = props.name;
   const localToken = props.localToken;
   const over24 = props.over24;
   const resupplyPeriod = props.resupplyPeriod;
-  const secondsInDay = 86400;
   let lastEstimate = props.lastEstimate;
   let latestInterval = props.latestInterval;
   let numberOfPurchases = props.numberOfPurchases;
   let nextPurchaseInterval = props.nextPurchaseInterval;
   let lastPurchaseDate = props.date;
-  let lastPurchasedTimeInSeconds = 0;
+
+  // Future implementation;  currently breaks but that's a low-priority issue.
+
+  // const { itemName, localToken, over24, resupplyPeriod } = props;
+  // let {
+  //   lastEstimate,
+  //   latestInterval,
+  //   numberOfPurchases,
+  //   nextPurchaseInterval,
+  //   lastPurchaseDate,
+  // } = props;
+
+  const [dropdownLastPurchaseDate, setDropdownLastPurchaseDate] = useState(
+    null,
+  );
 
   // To update the purchase date
   const markPurchased = event => {
@@ -44,6 +69,15 @@ const Item = props => {
       latestInterval,
       numberOfPurchases,
     );
+
+    // Sets date formatting for our dropdown view
+
+    let day = date.getDate();
+    const month = date.getMonth();
+    const year = date.getFullYear();
+    const parsedDate = `${month}/${day}/${year}`;
+
+    setDropdownLastPurchaseDate(parsedDate);
 
     firebase.dataBase
       .collection(localToken)
@@ -97,18 +131,29 @@ const Item = props => {
   });
 
   return (
-    <div
+    <Accordion
       id={itemId}
       onClick={markPurchased}
       aria-label={`Estimated number of days till next next purchase: ${nextPurchaseInterval}`}
     >
-      <Checkbox
-        checked={!over24}
-        value="checkedItem"
-        inputProps={{ 'aria-label': 'Checkbox Item' }}
-      />
-      {itemName}
-    </div>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="panel1a-content"
+        id="panel1a-header"
+      >
+        <Checkbox
+          checked={!over24}
+          value="checkedItem"
+          inputProps={{ 'aria-label': 'Checkbox Item' }}
+        />
+        <Typography>{itemName}</Typography>
+      </AccordionSummary>
+      <AccordionDetails>
+        {/* lastPurchaseDate, Estimated number of days until purchase is made, Number of times items  has been purchased*/}
+
+        {dropdownLastPurchaseDate}
+      </AccordionDetails>
+    </Accordion>
   );
 };
 

--- a/src/components/Item/Item.component.jsx
+++ b/src/components/Item/Item.component.jsx
@@ -133,7 +133,6 @@ const Item = props => {
   return (
     <Accordion
       id={itemId}
-      onClick={markPurchased}
       aria-label={`Estimated number of days till next next purchase: ${nextPurchaseInterval}`}
     >
       <AccordionSummary
@@ -144,14 +143,22 @@ const Item = props => {
         <Checkbox
           checked={!over24}
           value="checkedItem"
+          onClick={markPurchased}
           inputProps={{ 'aria-label': 'Checkbox Item' }}
         />
         <Typography>{itemName}</Typography>
       </AccordionSummary>
-      <AccordionDetails>
-        {/* lastPurchaseDate, Estimated number of days until purchase is made, Number of times items  has been purchased*/}
-
-        {dropdownLastPurchaseDate}
+      <AccordionDetails className="accordion__details">
+        <div className="flex-container">
+          {dropdownLastPurchaseDate
+            ? `Last Purchase Date: ${dropdownLastPurchaseDate}`
+            : "This item hasn't been purchased yet :("}
+        </div>
+        <div>
+          {' '}
+          {`Estimated number of days until next purchase: ${nextPurchaseInterval}`}
+        </div>
+        <div> {`Number of times purchased: ${numberOfPurchases}`}</div>
       </AccordionDetails>
     </Accordion>
   );

--- a/src/components/Item/Item.component.jsx
+++ b/src/components/Item/Item.component.jsx
@@ -104,7 +104,8 @@ const Item = props => {
 
   useEffect(() => {
     if (over24 === false) {
-      document.getElementById(itemId).style.textDecoration = 'line-through';
+      document.getElementById('item__name').style.textDecoration =
+        'line-through';
     }
     // To highlight the items based on resupplyPeriod
     if (resupplyPeriod === 7) {
@@ -141,12 +142,12 @@ const Item = props => {
         id="panel1a-header"
       >
         <Checkbox
+          onClick={markPurchased}
           checked={!over24}
           value="checkedItem"
-          onClick={markPurchased}
           inputProps={{ 'aria-label': 'Checkbox Item' }}
         />
-        <Typography>{itemName}</Typography>
+        <Typography id="item__name">{itemName}</Typography>
       </AccordionSummary>
       <AccordionDetails className="accordion__details">
         <div className="flex-container">

--- a/src/components/Item/Item.component.jsx
+++ b/src/components/Item/Item.component.jsx
@@ -10,7 +10,6 @@ import './Item.style.scss';
 import Accordion from '@material-ui/core/Accordion';
 import AccordionSummary from '@material-ui/core/AccordionSummary';
 import AccordionDetails from '@material-ui/core/AccordionDetails';
-import Typography from '@material-ui/core/Typography';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import Checkbox from '@material-ui/core/Checkbox';
 

--- a/src/components/Item/Item.component.jsx
+++ b/src/components/Item/Item.component.jsx
@@ -103,7 +103,9 @@ const Item = props => {
   };
 
   useEffect(() => {
-    if (over24 === false) {
+    if (!over24) {
+      // document.getElementById('item__name').style.textDecoration =
+      //   'line-through';
       document.getElementById('item__name').style.textDecoration =
         'line-through';
     }
@@ -129,6 +131,16 @@ const Item = props => {
         .getElementById(itemId)
         .setAttribute('class', 'list__item--inactive');
     }
+
+    // Set a state object thingmabob to act as dependency array trigger
+    // Handle Change method
+
+    //create over24 as local state, and pass props.over24 as its value, aka
+    // const [over24, setOver24] = useState(props.over24)
+
+    // useEffect(() => {
+    // do magic
+    // }, [over24])
   });
 
   return (
@@ -147,7 +159,7 @@ const Item = props => {
           value="checkedItem"
           inputProps={{ 'aria-label': 'Checkbox Item' }}
         />
-        <Typography id="item__name">{itemName}</Typography>
+        <h1 id="item__name">{itemName}</h1>
       </AccordionSummary>
       <AccordionDetails className="accordion__details">
         <div className="flex-container">

--- a/src/components/Item/Item.component.jsx
+++ b/src/components/Item/Item.component.jsx
@@ -102,15 +102,17 @@ const Item = props => {
 
   // Variable set up for easy theming whenever we want to get rid of these LOVELY colours LUL
   let accordionColor;
+  const soon = 7;
+  const kindOfSoon = 14;
 
   // Switch statement which looks for the resupply period  to match:
   // soon (7), kind of soon (14), and not soon (30).
   switch (resupplyPeriod) {
-    case 7:
+    case soon:
       accordionColor = 'yellow';
       break;
 
-    case 14:
+    case kindOfSoon:
       accordionColor = 'red';
       break;
 

--- a/src/components/Item/Item.style.scss
+++ b/src/components/Item/Item.style.scss
@@ -26,3 +26,17 @@
     }
   }
 }
+
+.flex {
+  &-container {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.MuiAccordionDetails-root {
+  flex-direction: column;
+  align-items: flex-start;
+  margin-left: 3.1rem;
+  font-size: 0.95rem;
+}

--- a/src/components/Item/Item.style.scss
+++ b/src/components/Item/Item.style.scss
@@ -5,28 +5,6 @@
   }
 }
 
-.Mui-checked {
-  text-decoration: line-through;
-}
-
-.list {
-  &__item {
-    &--soon {
-      background: yellow;
-    }
-    &--kind-of-soon {
-      background: red;
-    }
-    &--not-soon {
-      background: green;
-    }
-
-    &--inactive {
-      background: purple;
-    }
-  }
-}
-
 .flex {
   &-container {
     display: flex;

--- a/src/services/Listener/Listener.style.scss
+++ b/src/services/Listener/Listener.style.scss
@@ -1,4 +1,3 @@
-
 .search {
   &__bar {
     display: flex;
@@ -35,6 +34,9 @@
     margin: 2rem 0;
     font-size: 1.1rem;
     line-height: 1.5;
+    max-width: 100vw;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 }
-


### PR DESCRIPTION
## Description

This Pull Request (PR) adds a new feature to the `<Item />`, allowing users to view an item's purchase details by clicking on or near the 'down caret' icon. Users can click on or near the item's 'up caret' icon to no longer view an item's purchase details.

## Related Issue

Closes Issue #13

## Acceptance Criteria

- [x] From the shopping list, user can tap to navigate to a detailed view of the item
- [x] Detail view includes the following information:
- Name of the item
- Last purchased date
- Estimated number of days until the next purchase
- Number of times the item has been purchased
- [x] When in the “item details” view, a back arrow should appear in the header that takes the user back to the “list” view

## Type of Changes

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

![image](https://user-images.githubusercontent.com/32943879/93688366-4a2fbb00-fa93-11ea-8324-30d6669f22eb.png)

### After

![PurchaseItems](https://user-images.githubusercontent.com/32943879/93692669-fdb0a380-fac3-11ea-8e46-db9d6f07322b.gif)


## Testing Steps / QA Criteria

- From your terminal, run `git checkout bl-kl-view-purchase-details` in the `tcl-11-smart-shopping-list ` repository.
- Once on the `bl-kl-view-purchase-details` branch, run npm start to load the server and start the browser.
- Visit the `<Home/>` component at http://localhost:3000.
- Create a new shopping list, click the 'Create a New Shopping List' button to be redirected to the `<List />` component view. 
- Click the 'Add Item' button to be redirected to the `<AddItem />` component view and add any item to the shopping list.
- After the page reloads and the list of items is displayed, click on or near the item's 'down caret' icon to view an item's purchase details.
- Click on or near the item's 'up caret' icon to no longer view an item's purchase details.