### PR TITLE
Styling (Issue #17): Make Add Item View look welcoming

### DIFF
--- a/src/components/AddItem/AddItem.component.jsx
+++ b/src/components/AddItem/AddItem.component.jsx
@@ -12,6 +12,7 @@ import Listener from '../../services/Listener/Listener.service';
 
 import {
   Backdrop,
+  Button,
   Fade,
   IconButton,
   makeStyles,
@@ -35,6 +36,12 @@ const AddItem = props => {
   const numberOfPurchases = 0;
   const [resupplyPeriod, setResupplyPeriod] = useState(7);
   const itemId = randomString.generate(20);
+
+  const useStyles = makeStyles(theme => ({
+    submit: {
+      margin: theme.spacing(1, 0, 2),
+    },
+  }));
 
   //Material UI specific state and variables
   const [open, setOpen] = useState(false);
@@ -109,6 +116,8 @@ const AddItem = props => {
     setOpen(false);
   };
 
+  const classes = useStyles();
+
   return (
     <div className="page__container">
       <div className="page__content">
@@ -158,7 +167,15 @@ const AddItem = props => {
               How soon will you buy this again?
             </FormRadioButtons>
             <div className="button__container">
-              <CustomButton type="submit">Add Item</CustomButton>
+              <Button
+                type="submit"
+                variant="contained"
+                color="primary"
+                className={classes.submit}
+                size="large"
+              >
+                Add Item
+              </Button>
             </div>
           </div>
         </form>

--- a/src/components/AddItem/AddItem.component.jsx
+++ b/src/components/AddItem/AddItem.component.jsx
@@ -10,6 +10,16 @@ import {
 } from '../component.index';
 import Listener from '../../services/Listener/Listener.service';
 
+import {
+  Backdrop,
+  Fade,
+  IconButton,
+  makeStyles,
+  Modal,
+  Tooltip,
+} from '@material-ui/core';
+import AssignmentIcon from '@material-ui/icons/Assignment';
+
 import './AddItem.style.scss';
 
 const AddItem = props => {
@@ -25,6 +35,9 @@ const AddItem = props => {
   const numberOfPurchases = 0;
   const [resupplyPeriod, setResupplyPeriod] = useState(7);
   const itemId = randomString.generate(20);
+
+  //Material UI specific state and variables
+  const [open, setOpen] = useState(false);
 
   //To update the value on change
   const handleChange = event => {
@@ -68,6 +81,8 @@ const AddItem = props => {
           setTimeout(() => {
             setIsAdded(false);
           }, 1200);
+
+          setItemName('');
           return firebase.dataBase.collection(collectionTokenName).add({
             name: itemName,
             resupplyPeriod: resupplyPeriod,
@@ -84,38 +99,71 @@ const AddItem = props => {
       });
   };
 
+  // Handles modal opening and closing
+
+  const handleOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
   return (
-    <div className="classNewItem">
-      <h1 className="page__title">Add Item</h1>
-      <Listener localToken={collectionTokenName} />
-      <form onSubmit={addNewItemValue} className="item__form">
-        <div className="item__form__wrapper">
-          <div className="tooltip__container">
-            {/*conditionally renders tooltip based on if isAdded is truthy or falsy */}
-            <div
-              className={`${
-                isAdded ? 'tooltip--visible' : 'tooltip--invisible'
-              } tooltip`}
-            >
-              Success! Item added.
+    <div className="page__container">
+      <div className="page__content">
+        <h1 className="page__title">Add Item</h1>
+        <Tooltip title="View List!" onClick={handleOpen}>
+          <IconButton aria-label="View list">
+            <AssignmentIcon id="list__icon" />
+          </IconButton>
+        </Tooltip>
+        <Modal
+          open={open}
+          onClose={handleClose}
+          className="list__modal"
+          closeAfterTransition
+          BackdropComponent={Backdrop}
+          BackdropProps={{
+            timeout: 500,
+          }}
+        >
+          <Fade in={open}>
+            <div className="list__card">
+              {' '}
+              <Listener localToken={collectionTokenName} preview={true} />
+            </div>
+          </Fade>
+        </Modal>
+
+        <form onSubmit={addNewItemValue} className="item__form">
+          <div className="item__form__wrapper">
+            <div className="tooltip__container">
+              {/*conditionally renders tooltip based on if isAdded is truthy or falsy */}
+              <div
+                className={`${
+                  isAdded ? 'tooltip--visible' : 'tooltip--invisible'
+                } tooltip`}
+              >
+                Success! Item added.
+              </div>
+            </div>
+
+            <FormInput
+              label={'Item Name'}
+              value={itemName}
+              onChange={handleChange}
+            />
+            <FormRadioButtons handleRadioChange={handleRadioChange}>
+              How soon will you buy this again?
+            </FormRadioButtons>
+            <div className="button__container">
+              <CustomButton type="submit">Add Item</CustomButton>
             </div>
           </div>
-
-          {/*Added components to make return statement neater/easier to read.*/}
-          <FormInput
-            label={'Item Name'}
-            value={itemName}
-            onChange={handleChange}
-          />
-          <FormRadioButtons handleRadioChange={handleRadioChange}>
-            How soon will you buy this again?
-          </FormRadioButtons>
-          <div className="button__container">
-            <CustomButton type="submit">Add Item</CustomButton>
-          </div>
-        </div>
-      </form>
-      <Footer />
+        </form>
+      </div>
+      <Footer addItem={true} localToken={collectionTokenName} />
     </div>
   );
 };

--- a/src/components/AddItem/AddItem.style.scss
+++ b/src/components/AddItem/AddItem.style.scss
@@ -171,6 +171,10 @@
 // iPhone 5/SE specific layout
 @media screen and (max-width: 320px) {
   // Overall page layout
+  html,
+  body {
+    overflow-x: hidden;
+  }
   .page {
     &__content {
       width: 100vw;

--- a/src/components/AddItem/AddItem.style.scss
+++ b/src/components/AddItem/AddItem.style.scss
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Dancing+Script&display=swap');
+
 .item {
   &__form {
     display: flex;
@@ -15,25 +17,45 @@
 }
 
 .page {
+  &__container {
+    background-image: url(https://images.unsplash.com/photo-1571211905393-6de67ff8fb61?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1834&q=80);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    height: 100vh;
+    width: 100vw;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  &__content {
+    background: #e2f3f5;
+    box-shadow: 1px 2px 28px 0px rgba(0, 0, 0, 0.75);
+
+    border-radius: 4px;
+  }
   &__title {
-    padding-bottom: 2rem;
+    padding: 2rem 0;
+
+    margin-top: 0;
+    font-family: 'Dancing Script', cursive;
   }
 }
 
 .button__container {
   display: flex;
   justify-content: center;
-  padding-top: 4rem;
+  padding-top: 2rem;
 }
 
 .tooltip {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-bottom: 2rem;
   font-size: 1.1rem;
   background: rgb(8, 176, 243);
   width: 200px;
+  margin: 2rem 0;
   height: 50px;
   border-radius: 4px;
   vertical-align: auto;
@@ -59,6 +81,36 @@
 
     100% {
       opacity: 0;
+    }
+  }
+}
+
+// Modal Icon
+
+#list {
+  &__icon {
+    width: 1.6em;
+    height: 1.6em;
+  }
+}
+
+// Modal Styling
+
+.list {
+  &__modal {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__card {
+    padding: 1rem;
+    max-width: 550px;
+    box-shadow: -1px -2px 28px 0px rgba(0, 0, 0, 0.75);
+    background-color: whitesmoke;
+    border-radius: 4px;
+    &:focus {
+      outline: none;
     }
   }
 }

--- a/src/components/AddItem/AddItem.style.scss
+++ b/src/components/AddItem/AddItem.style.scss
@@ -42,10 +42,12 @@
   }
 }
 
-.button__container {
-  display: flex;
-  justify-content: center;
-  padding-top: 2rem;
+.button {
+  &__container {
+    display: flex;
+    justify-content: center;
+    padding-top: 2rem;
+  }
 }
 
 .tooltip {
@@ -111,6 +113,68 @@
     border-radius: 4px;
     &:focus {
       outline: none;
+    }
+  }
+}
+
+@media screen and (max-width: 620px) {
+  // Overall page layout
+  .page {
+    &__container {
+      width: 100vw;
+      height: 100%;
+    }
+    &__content {
+      width: 100vw;
+      height: calc(100vh + 10px);
+      border-radius: inherit;
+      box-shadow: none;
+    }
+  }
+
+  // "Tooltip" styling
+
+  .tooltip {
+    margin: 0.5rem 0;
+  }
+
+  .item {
+    &__wrapper {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+    }
+
+    &__form {
+      margin-bottom: 1rem;
+
+      &__wrapper {
+        width: 100%;
+      }
+    }
+  }
+
+  .button {
+    &__container {
+      padding-top: 1rem;
+    }
+  }
+
+  // modal styling
+  .list {
+    &__card {
+      max-width: 90vw;
+    }
+  }
+}
+
+// iPhone 5/SE specific layout
+@media screen and (max-width: 320px) {
+  // Overall page layout
+  .page {
+    &__content {
+      width: 100vw;
+      height: calc(100vh + 100px);
     }
   }
 }

--- a/src/components/CustomButton/CustomButton.style.scss
+++ b/src/components/CustomButton/CustomButton.style.scss
@@ -2,15 +2,16 @@
   &__button {
     cursor: pointer;
     width: 150px;
-    background: #0077ff;
+    background: #3f51b5;
     color: whitesmoke;
-    border: 2px solid #0077ff;
+    border: 2px solid #3f51b5;
     padding: 10px 5px;
     border-radius: 4px;
     box-shadow: none;
     font-size: 1.1rem;
     text-align: center;
     transition: all 0.2s ease-in-out;
+    font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
 
     &--large {
       width: 250px;

--- a/src/components/Footer/Footer.component.jsx
+++ b/src/components/Footer/Footer.component.jsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 
 import './Footer.style.scss';
 
-const Footer = () => (
+const Footer = ({ addItem, localToken }) => (
   <div className="footer__container">
     <NavLink
       className="footer__link"
@@ -13,6 +13,15 @@ const Footer = () => (
     >
       Home
     </NavLink>
+    {addItem ? (
+      <NavLink
+        className="footer__link"
+        to={{ pathname: '/list', state: { localToken: localToken } }}
+        activeClassName="footer__link--active"
+      >
+        List
+      </NavLink>
+    ) : null}
   </div>
 );
 

--- a/src/components/Footer/Footer.style.scss
+++ b/src/components/Footer/Footer.style.scss
@@ -19,3 +19,15 @@
     }
   }
 }
+
+@media screen and (max-width: 620px) {
+  .footer {
+    &__container {
+      background: #e2f3f5;
+    }
+
+    &__link {
+      padding: 0 2rem;
+    }
+  }
+}

--- a/src/components/Footer/Footer.style.scss
+++ b/src/components/Footer/Footer.style.scss
@@ -2,15 +2,16 @@
   &__container {
     width: 100vw;
     position: fixed;
-    padding-bottom: 1rem;
     bottom: 0;
+    height: 40px;
   }
 
   &__link {
     padding: 2rem;
     color: black;
     text-decoration: none;
-    font-size: 1.2rem;
+    font-size: 1.4rem;
+    font-weight: 600;
 
     &--active {
       color: #4f4fbb;

--- a/src/components/FormInput/FormInput.component.jsx
+++ b/src/components/FormInput/FormInput.component.jsx
@@ -3,11 +3,13 @@ import React from 'react';
 import './FormInput.style.scss';
 
 const FormInput = ({ htmlFor, label, ...otherProps }) => (
-  <div className="form__group">
-    <label htmlFor={htmlFor} className="item__label">
-      {label}:
-    </label>
-    <input type="text" {...otherProps} required className="form__input" />
+  <div className="form-input__container">
+    <div className="form__group">
+      <label htmlFor={htmlFor} className="item__label">
+        {label}:
+      </label>
+      <input type="text" {...otherProps} required className="form__input" />
+    </div>
   </div>
 );
 

--- a/src/components/FormInput/FormInput.style.scss
+++ b/src/components/FormInput/FormInput.style.scss
@@ -1,14 +1,19 @@
+.form-input {
+  &__container {
+    margin: 0 auto;
+  }
+}
+
 .form {
   &__group {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    padding-left: 14px;
+    margin-bottom: 3rem;
   }
 
   &__input {
-    margin-bottom: 1.5rem;
-    width: 240px;
+    width: 350px;
     height: 40px;
     border-radius: 4px;
     box-shadow: none;

--- a/src/components/FormInput/FormInput.style.scss
+++ b/src/components/FormInput/FormInput.style.scss
@@ -34,3 +34,27 @@
     font-weight: 600;
   }
 }
+
+@media screen and (max-width: 620px) {
+  .form-input {
+    &__container {
+      width: 90vw;
+      display: flex;
+      justify-content: center;
+    }
+  }
+
+  .form {
+    &__group {
+      margin-bottom: 1rem;
+    }
+
+    &__legend {
+      font-size: 1.1rem;
+    }
+
+    &__input {
+      width: 90vw;
+    }
+  }
+}

--- a/src/components/FormRadioButtons/FormRadioButtons.component.jsx
+++ b/src/components/FormRadioButtons/FormRadioButtons.component.jsx
@@ -7,7 +7,7 @@ const FormRadioButtons = ({ children, handleRadioChange }) => (
   // This helps with screen readers.
   <fieldset className="form__fieldset">
     <legend className="form__legend">{children}</legend>
-    <label htmlFor="soon" className="form__label">
+    <div className="form__container">
       <input
         type="radio"
         name="soon"
@@ -17,9 +17,9 @@ const FormRadioButtons = ({ children, handleRadioChange }) => (
         onChange={handleRadioChange}
         className="form__radio"
       />
-      Soon
-    </label>
-    <label htmlFor="kind-of-soon" className="form__label">
+      <label htmlFor="soon" className="form__label form__label--soon">
+        Soon
+      </label>
       <input
         type="radio"
         name="soon"
@@ -28,9 +28,13 @@ const FormRadioButtons = ({ children, handleRadioChange }) => (
         onChange={handleRadioChange}
         className="form__radio"
       />
-      Kind of Soon
-    </label>
-    <label htmlFor="not-soon" className="form__label">
+      <label
+        htmlFor="kind-of-soon"
+        className="form__label form__label--kind-of-soon"
+      >
+        Kind of Soon
+      </label>
+
       <input
         type="radio"
         name="soon"
@@ -39,8 +43,10 @@ const FormRadioButtons = ({ children, handleRadioChange }) => (
         onChange={handleRadioChange}
         className="form__radio"
       />
-      Not Soon
-    </label>
+      <label htmlFor="not-soon" className="form__label form__label--not-soon">
+        Not Soon
+      </label>
+    </div>
   </fieldset>
 );
 

--- a/src/components/FormRadioButtons/FormRadioButtons.style.scss
+++ b/src/components/FormRadioButtons/FormRadioButtons.style.scss
@@ -2,24 +2,54 @@
   &__fieldset {
     border: none;
     display: flex;
-    flex-direction: column;
     align-items: flex-start;
     justify-content: center;
     font-size: 1.1rem;
   }
 
   &__legend {
-    padding-top: 2rem;
+    padding: 1.8rem 0;
+    font-size: 1.2rem;
+    font-weight: 600;
+  }
+
+  &__container {
+    display: flex;
+    margin-bottom: 3rem;
   }
 
   &__label {
     display: flex;
     cursor: pointer;
-    margin-top: 20px;
-    color: grey;
+    margin-top: 10px;
+    border-radius: 4px;
+    height: 5rem;
+    width: 10rem;
+    color: rgb(0, 0, 0);
+    align-items: center;
+    justify-content: center;
+    margin: 0px 5px;
+    transition: all 0.2s ease-in-out;
+
+    &--soon {
+      background-color: #fffeb8;
+    }
+    &--kind-of-soon {
+      background-color: #ffe4d6;
+    }
+    &--not-soon {
+      background-color: #ace6f6;
+    }
   }
 
   &__radio {
     margin: 5px 10px 0 0;
+    display: none;
+
+    &:checked + label {
+      box-shadow: 0 0 3px rgb(133, 133, 133);
+      font-weight: bold;
+      font-size: 1.2rem;
+    }
   }
 }

--- a/src/components/FormRadioButtons/FormRadioButtons.style.scss
+++ b/src/components/FormRadioButtons/FormRadioButtons.style.scss
@@ -60,3 +60,22 @@ $labelColor: hsla(100, 100, 100, 1);
     }
   }
 }
+
+@media screen and (max-width: 620px) {
+  .form {
+    &__container {
+      width: 93vw;
+      margin-bottom: 1.5rem;
+    }
+
+    &__legend {
+      font-size: 1.1rem;
+    }
+
+    &__radio {
+      &:checked + label {
+        font-size: 1.05rem;
+      }
+    }
+  }
+}

--- a/src/components/FormRadioButtons/FormRadioButtons.style.scss
+++ b/src/components/FormRadioButtons/FormRadioButtons.style.scss
@@ -1,3 +1,6 @@
+// Radio button style variables
+$labelColor: hsla(100, 100, 100, 1);
+
 .form {
   &__fieldset {
     border: none;
@@ -30,15 +33,19 @@
     justify-content: center;
     margin: 0px 5px;
     transition: all 0.2s ease-in-out;
+    background-color: $labelColor;
 
     &--soon {
-      background-color: #fffeb8;
+      $labelColor: hsla(59, 100%, 86%, 1);
+      background-color: $labelColor;
     }
     &--kind-of-soon {
-      background-color: #ffe4d6;
+      $labelColor: hsla(20, 100%, 92%, 1);
+      background-color: $labelColor;
     }
     &--not-soon {
-      background-color: #ace6f6;
+      $labelColor: hsla(193, 80%, 82%, 1);
+      background-color: $labelColor;
     }
   }
 
@@ -47,7 +54,7 @@
     display: none;
 
     &:checked + label {
-      box-shadow: 0 0 3px rgb(133, 133, 133);
+      box-shadow: 0 0 3px darken(hsl(186, 48, 92), 40%);
       font-weight: bold;
       font-size: 1.2rem;
     }

--- a/src/components/List/List.component.jsx
+++ b/src/components/List/List.component.jsx
@@ -39,7 +39,7 @@ const List = props => {
         </>
       )}
       <> </>
-      <Footer />
+      <Footer addItem={false} />
     </div>
   );
 };

--- a/src/services/Listener/Listener.service.jsx
+++ b/src/services/Listener/Listener.service.jsx
@@ -111,7 +111,7 @@ const Listener = props => {
     <>
       <div className="listener__container">{isEmpty ? <Card /> : null}</div>
       <div className="search__container">
-        <div className="search__bar">
+        <div className={`${preview ? 'search__preview' : ''} search__bar`}>
           <input
             type="text"
             className="search__input"

--- a/src/services/Listener/Listener.service.jsx
+++ b/src/services/Listener/Listener.service.jsx
@@ -26,9 +26,6 @@ const Listener = props => {
     unfilteredItems.forEach(unfilteredItem => {
       unfilteredArray.push(unfilteredItem);
 
-      // const searchFilter = unfilteredArray.filter(unfilteredArray =>
-      //   unfilteredArray.toLowerCase().includes(searchData.toLowerCase()),
-      // );
       for (const shopItem of unfilteredArray) {
         const searchFilter = unfilteredArray.filter(unfilteredArray =>
           unfilteredArray.name.toLowerCase().includes(searchData.toLowerCase()),

--- a/src/services/Listener/Listener.service.jsx
+++ b/src/services/Listener/Listener.service.jsx
@@ -14,6 +14,7 @@ const Listener = props => {
   const [localToken, SetLocalToken] = useState(props.localToken);
   const [searchData, setSearchData] = useState([]);
   const [unfilteredItems, setUnfilteredItems] = useState([]);
+  const preview = props.preview;
   const secondsInDay = 86400;
 
   useEffect(() => {
@@ -23,13 +24,17 @@ const Listener = props => {
   useEffect(() => {
     let unfilteredArray = [];
     unfilteredItems.forEach(unfilteredItem => {
-      unfilteredArray.push(unfilteredItem.name);
+      unfilteredArray.push(unfilteredItem);
 
-      const searchFilter = unfilteredArray.filter(unfilteredArray =>
-        unfilteredArray.toLowerCase().includes(searchData.toLowerCase()),
-      );
-
-      setFilteredItems(searchFilter);
+      // const searchFilter = unfilteredArray.filter(unfilteredArray =>
+      //   unfilteredArray.toLowerCase().includes(searchData.toLowerCase()),
+      // );
+      for (const shopItem of unfilteredArray) {
+        const searchFilter = unfilteredArray.filter(unfilteredArray =>
+          unfilteredArray.name.toLowerCase().includes(searchData.toLowerCase()),
+        );
+        setFilteredItems(searchFilter);
+      }
     });
   }, [searchData]);
 
@@ -105,24 +110,26 @@ const Listener = props => {
   return (
     <>
       <div className="listener__container">{isEmpty ? <Card /> : null}</div>
-      <div className="search__bar">
-        <input
-          type="text"
-          className="search__input"
-          placeholder="Search..."
-          value={searchData}
-          onChange={handleChange}
-        />
+      <div className="search__container">
+        <div className="search__bar">
+          <input
+            type="text"
+            className="search__input"
+            placeholder="Search..."
+            value={searchData}
+            onChange={handleChange}
+          />
 
-        <CrossIcon
-          className={`${
-            searchData.length ? '' : 'search__icon--invisible'
-          } search__icon`}
-          onClick={clearSearch}
-        />
+          <CrossIcon
+            className={`${
+              searchData.length ? '' : 'search__icon--invisible'
+            } search__icon`}
+            onClick={clearSearch}
+          />
+        </div>
       </div>
 
-      <div className="items__list">
+      <div className={`${preview ? 'items__preview' : ''} items__list`}>
         {searchData.length < 1 ? (
           unfilteredItems.map(item => (
             <Item
@@ -140,9 +147,21 @@ const Listener = props => {
             ></Item>
           ))
         ) : (
-          <div>
+          <div className={`${preview ? 'items__preview' : ''} items__list`}>
             {filteredItems.map(filteredItem => (
-              <div> {filteredItem} </div>
+              <Item
+                key={filteredItem.id}
+                name={filteredItem.name}
+                id={filteredItem.id}
+                date={filteredItem.lastPurchaseDate}
+                localToken={localToken}
+                over24={filteredItem.over24}
+                lastEstimate={filteredItem.lastEstimate}
+                latestInterval={filteredItem.latestInterval}
+                numberOfPurchases={filteredItem.numberOfPurchases}
+                nextPurchaseInterval={filteredItem.nextPurchaseInterval}
+                resupplyPeriod={filteredItem.resupplyPeriod}
+              />
             ))}
           </div>
         )}

--- a/src/services/Listener/Listener.style.scss
+++ b/src/services/Listener/Listener.style.scss
@@ -1,13 +1,20 @@
 .search {
+  &__container {
+    margin: 1rem 0 0 1.3rem;
+  }
+
   &__bar {
     display: flex;
     justify-content: center;
     align-items: center;
+    text-align: center;
+    width: 440px;
   }
 
   &__input {
-    width: 350px;
-    height: 30px;
+    width: 550px;
+    height: 40px;
+    margin: 0 auto;
     border-radius: 4px;
     box-shadow: none;
     outline: none;
@@ -31,12 +38,16 @@
 
 .items {
   &__list {
-    margin: 2rem 0;
+    margin: 2rem 0 0;
     font-size: 1.1rem;
     line-height: 1.5;
     max-width: 100vw;
     display: flex;
     flex-direction: column;
     align-items: center;
+  }
+  &__preview {
+    max-height: 30vh;
+    overflow-y: scroll;
   }
 }

--- a/src/services/Listener/Listener.style.scss
+++ b/src/services/Listener/Listener.style.scss
@@ -11,6 +11,16 @@
     width: 440px;
   }
 
+  // attempt to prevent issues stemming from different placement used in List view;
+  // This may be unnecessary when merged with volha/kathy branch.
+  &__preview {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    width: 440px;
+  }
+
   &__input {
     width: 550px;
     height: 40px;

--- a/src/services/Listener/Listener.style.scss
+++ b/src/services/Listener/Listener.style.scss
@@ -8,21 +8,10 @@
     justify-content: center;
     align-items: center;
     text-align: center;
-    width: 440px;
-  }
-
-  // attempt to prevent issues stemming from different placement used in List view;
-  // This may be unnecessary when merged with volha/kathy branch.
-  &__preview {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    width: 440px;
   }
 
   &__input {
-    width: 550px;
+    width: 350px;
     height: 40px;
     margin: 0 auto;
     border-radius: 4px;

--- a/src/services/Listener/Listener.style.scss
+++ b/src/services/Listener/Listener.style.scss
@@ -61,3 +61,11 @@
     overflow-y: scroll;
   }
 }
+
+@media screen and (max-width: 620px) {
+  .search {
+    &__bar {
+      width: 85vw;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Updated  `<AddItem />` view to be more attractively styled and responsive.

## Related Issue
 Closes issue #17 


## Acceptance Criteria

- The add an item screen (the screen a user uses to add a new item to their list) looks something like the following (or equivalent, use your creativity!):

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓    | :hammer: Refactoring       |


## Updates

### Before

![image](https://user-images.githubusercontent.com/6282435/94358251-ac795480-006d-11eb-8051-073bd5851949.png)



### After

![image](https://user-images.githubusercontent.com/6282435/94358546-e6e3f100-006f-11eb-81a9-74c113b55f91.png)



## Testing Steps / QA Criteria

- From your terminal, run `git checkout bl-sd-additem-styling`.
- Once on the ` bl-sd-additem-styling` branch, run `npm run start`.
- Create a new shopping list or access an existing one (if you already have one).
- Click the "Add Item" button to navigate to the `AddItem` view.
